### PR TITLE
Add dark mode toggle

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -25,7 +25,7 @@ function toggleTheme() {
 
         <!-- 다크모드 버튼 -->
         <button @click="toggleTheme" class="ml-4 text-gray-700 dark:text-gray-200 hover:text-purple-600">
-          <Icon :name="colorMode === 'dark' ? 'heroicons:moon' : 'heroicons:sun'" class="w-5 h-5" />
+          <Icon :name="colorMode.value === 'dark' ? 'heroicons:moon' : 'heroicons:sun'" class="w-5 h-5" />
         </button>
       </nav>
 
@@ -43,8 +43,8 @@ function toggleTheme() {
 
       <!-- 모바일에서도 다크모드 버튼 -->
       <button @click="toggleTheme" class="block text-gray-700 dark:text-gray-200 hover:text-purple-600">
-        <Icon :name="colorMode === 'dark' ? 'heroicons:moon' : 'heroicons:sun'" class="w-5 h-5" />
-        <span class="ml-2">{{ colorMode === 'dark' ? '다크모드' : '라이트모드' }}</span>
+        <Icon :name="colorMode.value === 'dark' ? 'heroicons:moon' : 'heroicons:sun'" class="w-5 h-5" />
+        <span class="ml-2">{{ colorMode.value === 'dark' ? '다크모드' : '라이트모드' }}</span>
       </button>
     </div>
   </header>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@nuxt/icon": "^1.13.0",
     "@nuxt/image": "^1.10.0",
     "@nuxt/ui": "^3.1.3",
+    "@vueuse/core": "^13.3.0",
     "eslint": "^9.28.0",
     "nuxt": "^3.17.5",
     "pretendard": "^1.3.9",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+    darkMode: 'class',
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
## Summary
- enable class-based Tailwind dark mode
- include `@vueuse/core` for color mode support
- update header component to switch themes

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68495ff9b4a88331bff0662a91284e1c