### PR TITLE
Fix CISA API path

### DIFF
--- a/server/api/cisa.ts
+++ b/server/api/cisa.ts
@@ -1,8 +1,10 @@
 import { readFile } from 'fs/promises'
-import { join } from 'path'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
 export default defineEventHandler(async () => {
-  const filePath = join(process.cwd(), 'content', 'cisa', 'cisa.json')
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const filePath = join(__dirname, '../../content/cisa/cisa.json')
   const data = await readFile(filePath, 'utf-8')
   return JSON.parse(data)
 })


### PR DESCRIPTION
## Summary
- fix cisa API file path resolution so it works after build

## Testing
- `npm install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684a1f4bf78883318c658f9aec2b109c